### PR TITLE
Расширен pom.xml добавлен трансформер для heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ hs_err_pid*
 *~
 /cov-int/
 *.tgz
+/dependency-reduced-pom.xml

--- a/config.yaml
+++ b/config.yaml
@@ -5,13 +5,13 @@ messageRepetitions: 3
 
 # use the simple server factory if you only want to run on a single port
 # HEROKU NOTE - the port gets be overridden with the Heroku $PORT in the Procfile
-#server:
-#  type: simple
-#  applicationContextPath: /
+server:
+  type: simple
+  applicationContextPath: /
 #  #adminContextPath: /admin # If you plan to use an admin path, you'll need to also use non-root app path
-#  connector:
-#    type: http
-#    port: 8080
+  connector:
+    type: http
+    port: 8080
 
 # Logging settings.
 #logging:

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
             </goals>
             <configuration>
             <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                 <mainClass>com/taxtelecom/chelnyedu/dropwizard/App</mainClass>
             </transformer>


### PR DESCRIPTION
Добавлен трансформер org.apache.maven.plugins.shade.resource.ServicesResourceTransformer
в pom.xml без которого невозможно было запустить приложение с кастомным портом.

Расширен .gitignore - добавлено игнорирование автосоздаваемого уменьшенного файла pom

Внесены изменения в конфигурационный файл для возможности переопределять порт кастомный
порт сервиса.